### PR TITLE
fix: filter log4j libs from forge v2 installers. 

### DIFF
--- a/daedalus/src/lib.rs
+++ b/daedalus/src/lib.rs
@@ -4,9 +4,7 @@
 
 #![warn(missing_docs, unused_import_braces, missing_debug_implementations)]
 
-use std::{
-    convert::TryFrom, fmt::Display, path::PathBuf, str::FromStr,
-};
+use std::{convert::TryFrom, fmt::Display, path::PathBuf, str::FromStr};
 
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
@@ -153,7 +151,10 @@ impl GradleSpecifier {
     }
 
     /// Construct a url for the artifact from a given base
-    pub fn into_url(&self, base_url: &str) -> Result<url::Url, url::ParseError> {
+    pub fn into_url(
+        &self,
+        base_url: &str,
+    ) -> Result<url::Url, url::ParseError> {
         let url = url::Url::parse(base_url)?;
         url.join(&self.path())
     }
@@ -606,7 +607,8 @@ mod tests {
                 .join("example-1.0.0+beta1.2.jar")
         );
 
-        let coordinates = "com.example:example-mc:1.0.0:natives-example".to_string();
+        let coordinates =
+            "com.example:example-mc:1.0.0:natives-example".to_string();
         let parsed_coordinates =
             GradleSpecifier::from_str(&coordinates).unwrap();
         let path = parsed_coordinates.into_path();

--- a/daedalus_client/Cargo.toml
+++ b/daedalus_client/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1", features = ["full"] }
 futures = "0.3.25"
 dotenvy = "0.15.6"
 log = "0.4.17"
-env_logger= "0.10.0"
+env_logger = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4.0"
@@ -28,9 +28,8 @@ walkdir = "2.3.3"
 path-slash = "0.2.1"
 
 [features]
-default = [ "forge", "fabric", "quilt",]
+default = ["forge", "fabric", "quilt"]
 save_local = []
 forge = []
 fabric = []
 quilt = []
-

--- a/daedalus_client/Cargo.toml
+++ b/daedalus_client/Cargo.toml
@@ -28,8 +28,9 @@ walkdir = "2.3.3"
 path-slash = "0.2.1"
 
 [features]
-default = ["forge", "fabric", "quilt"]
+default = [ "forge", "fabric", "quilt",]
 save_local = []
 forge = []
 fabric = []
 quilt = []
+

--- a/daedalus_client/src/forge.rs
+++ b/daedalus_client/src/forge.rs
@@ -492,16 +492,7 @@ pub async fn retrieve_data(
                                     let now = Instant::now();
 
 
-                                    let minecraft_libs_filter = {
-                                        let mut mc_library_cache = mc_library_cache_mutex.lock().await;
-                                        mc_library_cache.load_minecraft_version_libs(&profile.minecraft).await?.clone()
-                                    };
                                     let libs = futures::future::try_join_all(libs.into_iter().map(|mut lib| async {
-
-                                        if lib.name.is_lwjgl() || lib.name.is_log4j() || should_ignore_artifact(&minecraft_libs_filter, &lib.name) {
-                                            return Ok::<Option<Library>, Error>(None);
-                                        }
-
 
                                         let artifact_path = lib.name.path();
 

--- a/daedalus_client/src/forge.rs
+++ b/daedalus_client/src/forge.rs
@@ -135,13 +135,26 @@ pub async fn retrieve_data(
     uploaded_files: &mut Vec<String>,
     semaphore: Arc<Semaphore>,
 ) -> Result<(), Error> {
+    log::info!("Retrieving Forge data ...");
+
     let maven_metadata = fetch_maven_metadata(None, semaphore.clone()).await?;
-    let old_manifest = daedalus::modded::fetch_manifest(&format_url(&format!(
-        "forge/v{}/manifest.json",
-        daedalus::modded::CURRENT_FORGE_FORMAT_VERSION,
-    )))
-    .await
-    .ok();
+
+    let old_manifest = if cfg!(feature = "save_local") {
+        log::info!("Loading local Forge manifest ...");
+        crate::load_file_local(format!(
+            "forge/v{}/manifest.json",
+            daedalus::modded::CURRENT_FORGE_FORMAT_VERSION,
+        ))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+    } else {
+        daedalus::modded::fetch_manifest(&format_url(&format!(
+            "forge/v{}/manifest.json",
+            daedalus::modded::CURRENT_FORGE_FORMAT_VERSION,
+        )))
+        .await
+        .ok()
+    };
 
     let old_versions =
         Arc::new(Mutex::new(if let Some(old_manifest) = old_manifest {
@@ -383,17 +396,24 @@ pub async fn retrieve_data(
                                     }).await??;
 
 
-                                    let mut libs : Vec<Library> = version_info.libraries.into_iter().chain(profile.libraries.into_iter().map(|x| Library {
-                                        downloads: x.downloads,
-                                        extract: x.extract,
-                                        name: x.name,
-                                        url: x.url,
-                                        natives: x.natives,
-                                        rules: x.rules,
-                                        checksums: x.checksums,
-                                        include_in_classpath: false,
-                                        patched: false,
-                                    })).collect();
+                                    let mut libs : Vec<Library> = version_info.libraries
+                                        .into_iter()
+                                        .chain(profile.libraries
+                                            .into_iter()
+                                            .map(|x| Library {
+                                                downloads: x.downloads,
+                                                extract: x.extract,
+                                                name: x.name,
+                                                url: x.url,
+                                                natives: x.natives,
+                                                rules: x.rules,
+                                                checksums: x.checksums,
+                                                include_in_classpath: false,
+                                                patched: false,
+                                            })
+                                        )
+                                        .filter(|lib| !lib.name.is_log4j() )
+                                        .collect();
 
                                     let mut local_libs : HashMap<String, bytes::Bytes> = HashMap::new();
 
@@ -787,4 +807,3 @@ struct ForgeInstallerProfileV2 {
     pub libraries: Vec<Library>,
     pub processors: Vec<Processor>,
 }
-

--- a/daedalus_client/src/main.rs
+++ b/daedalus_client/src/main.rs
@@ -264,6 +264,19 @@ pub async fn save_file_local(
     Ok(())
 }
 
+/// Load a local file
+/// mainly for testing
+pub fn load_file_local(path: String) -> Result<Vec<u8>, Error> {
+    info!("{} saving locally", path);
+
+    let local_save_dir = std::path::Path::new(&LOCAL_SAVE_PATH);
+    let load_path = local_save_dir.join(&path);
+
+    let bytes = std::fs::read(&load_path).map_err(|err| Error::IoError(err))?;
+
+    Ok(bytes)
+}
+
 pub fn format_url(path: &str) -> String {
     format!("{}/{}", &*dotenvy::var("BASE_URL").unwrap(), path)
 }

--- a/daedalus_client/src/quilt.rs
+++ b/daedalus_client/src/quilt.rs
@@ -11,7 +11,26 @@ pub async fn retrieve_data(
     uploaded_files: &mut Vec<String>,
     semaphore: Arc<Semaphore>,
 ) -> Result<(), Error> {
+    log::info!("Retrieving Quilt data ...");
+
     let mut list = fetch_quilt_versions(None, semaphore.clone()).await?;
+
+    let old_manifest = if cfg!(feature = "save_local") {
+        log::info!("Loading local Quilt manifest ...");
+        crate::load_file_local(format!(
+            "quilt/v{}/manifest.json",
+            daedalus::modded::CURRENT_QUILT_FORMAT_VERSION,
+        ))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+    } else {
+        daedalus::modded::fetch_manifest(&format_url(&format!(
+            "quilt/v{}/manifest.json",
+            daedalus::modded::CURRENT_QUILT_FORMAT_VERSION,
+        )))
+        .await
+        .ok()
+    };
     let old_manifest = daedalus::modded::fetch_manifest(&format_url(&format!(
         "quilt/v{}/manifest.json",
         daedalus::modded::CURRENT_QUILT_FORMAT_VERSION,


### PR DESCRIPTION
- also make feature "save_local" load locally saved manifests