### PR TITLE
feat: Add support for Minecraft 26.1 (JavaRuntimeEpsilon & DefaultUserJvm)

### DIFF
--- a/daedalus/src/minecraft.rs
+++ b/daedalus/src/minecraft.rs
@@ -84,7 +84,7 @@ pub enum MinecraftJavaProfile {
     MinecraftJavaExe,
     /// Java 21
     JavaRuntimeDelta,
-
+    /// Java 25
     JavaRuntimeEpsilon,
     #[serde(untagged)]
     /// Unknown

--- a/daedalus/src/minecraft.rs
+++ b/daedalus/src/minecraft.rs
@@ -103,6 +103,7 @@ impl MinecraftJavaProfile {
                 Ok("java-runtime-gamma-snapshot")
             }
             MinecraftJavaProfile::JavaRuntimeDelta => Ok("java-runtime-delta"),
+            MinecraftJavaProfile::JavaRuntimeEpsilon => Ok("java-runtime-epsilon"),
             MinecraftJavaProfile::MinecraftJavaExe => Ok("minecraft-java-exe"),
             MinecraftJavaProfile::Unknown(value) => {
                 Err(Error::InvalidMinecraftJavaProfile(value.to_string()))
@@ -124,6 +125,7 @@ impl TryFrom<&str> for MinecraftJavaProfile {
                 Ok(MinecraftJavaProfile::JavaRuntimeGammaSnapshot)
             }
             "java-runtime-delta" => Ok(MinecraftJavaProfile::JavaRuntimeDelta),
+            "java-runtime-epsilon" => Ok(MinecraftJavaProfile::JavaRuntimeEpsilon),
             "minecraft-java-exe" => Ok(MinecraftJavaProfile::MinecraftJavaExe),
             _ => Err(Error::InvalidMinecraftJavaProfile(value.to_string())),
         }

--- a/daedalus/src/minecraft.rs
+++ b/daedalus/src/minecraft.rs
@@ -592,6 +592,7 @@ pub enum ArgumentType {
     Game,
     /// The argument is passed to the JVM
     Jvm,
+    #[serde(rename = "default-user-jvm")]
     /// Default JVM arguments that users can customize
     DefaultUserJvm,
 }

--- a/daedalus/src/minecraft.rs
+++ b/daedalus/src/minecraft.rs
@@ -84,6 +84,8 @@ pub enum MinecraftJavaProfile {
     MinecraftJavaExe,
     /// Java 21
     JavaRuntimeDelta,
+
+    JavaRuntimeEpsilon,
     #[serde(untagged)]
     /// Unknown
     Unknown(String),


### PR DESCRIPTION
## Summary
This PR adds support for Minecraft 26.1 by introducing the `JavaRuntimeEpsilon` variant to `MinecraftJavaProfile` and the `DefaultUserJvm` variant to `ArgumentType`.

## Motivation
Minecraft 26.1 (and recent snapshots) introduces:
1. A new Java runtime requirement identified as `java-runtime-epsilon`.
2. A new argument type `default-user-jvm`.

Currently, the launcher fails to parse the version manifest and arguments for these versions. This change allows Daedalus to correctly recognize and handle these new fields.

## Changes
- Added `JavaRuntimeEpsilon` to `MinecraftJavaProfile` and updated its string conversion methods.
- Added `DefaultUserJvm` to `ArgumentType` (mapped via serde).

## Verification
Verified that the launcher can now successfully parse and launch Minecraft 26.1 instances without crashing on the version check or argument parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the "java-runtime-epsilon" Java runtime environment, allowing users to select and configure this new Java runtime profile when launching Minecraft instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->